### PR TITLE
feat: UX batch 2 — nav fix, em highlight, back-to-top, skills grid, social URLs

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -7,7 +7,7 @@ export interface Props { locale: Locale }
 const { locale } = Astro.props;
 const dict = t(locale);
 const resumeUrl = site.resumeUrlByLocale[locale];
-const linkedinUrl = `${site.socials.linkedin}?locale=${locale === 'es' ? 'es_ES' : 'en_US'}`;
+const linkedinUrl = site.socials.linkedinByLocale[locale];
 ---
 <section class="contact container" id="contact">
   <div class="section-meta">{dict.contact.sectionMeta}</div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -9,6 +9,7 @@ const { locale } = Astro.props;
 const dict = t(locale);
 ---
 <a href="#about" class="skip-link">{locale === 'es' ? 'Saltar al contenido' : 'Skip to content'}</a>
+<button class="back-to-top" id="back-to-top" aria-label={locale === 'es' ? 'Volver arriba' : 'Back to top'}>↑</button>
 
 <nav class="nav" aria-label={locale === 'es' ? 'Principal' : 'Primary'}>
   <div class="scroll-progress" aria-hidden="true"><span class="scroll-progress-fill"></span></div>
@@ -258,6 +259,31 @@ const dict = t(locale);
 
   /* Lock body scroll when drawer open */
   :global(body.nav-open) { overflow: hidden; }
+
+  /* Back to top */
+  .back-to-top {
+    position: fixed;
+    bottom: 28px; right: 28px;
+    z-index: 90;
+    width: 48px; height: 48px;
+    background: var(--accent);
+    color: var(--accent-ink);
+    border: 2px solid var(--accent);
+    font-family: var(--font-mono);
+    font-size: 20px; font-weight: 900;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    opacity: 0; pointer-events: none;
+    transform: translateY(12px);
+    transition: opacity .25s ease, transform .25s ease, background .15s ease;
+    line-height: 1;
+  }
+  .back-to-top.visible { opacity: 1; pointer-events: auto; transform: none; }
+  .back-to-top:hover { background: var(--fg); color: var(--bg); border-color: var(--fg); }
+  .back-to-top:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  @media (max-width: 560px) {
+    .back-to-top { bottom: 16px; right: 16px; width: 42px; height: 42px; font-size: 17px; }
+  }
 </style>
 
 <script>
@@ -330,6 +356,15 @@ const dict = t(locale);
   update();
   window.addEventListener('scroll', update, { passive: true });
   window.addEventListener('resize', update);
+
+  // Back to top
+  const btt = document.getElementById('back-to-top') as HTMLButtonElement | null;
+  const updateBtt = () => {
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    btt?.classList.toggle('visible', max > 0 && window.scrollY / max > 0.5);
+  };
+  window.addEventListener('scroll', updateBtt, { passive: true });
+  btt?.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
 
   // Reveal-on-scroll for anything tagged .reveal
   const reveals = document.querySelectorAll<HTMLElement>('.reveal');

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -25,7 +25,10 @@ export const site = {
     en: '/cv.html',
   } satisfies Record<Locale, string>,
   socials: {
-    linkedin: 'https://www.linkedin.com/in/martincolladodev/',
+    linkedinByLocale: {
+      es: 'https://www.linkedin.com/in/martincolladodev/?locale=es_ES',
+      en: 'https://www.linkedin.com/in/martincolladodev/?locale=en_US',
+    } satisfies Record<Locale, string>,
     github: 'https://github.com/martincollado',
     instagram: 'https://www.instagram.com/mcolladophotography/',
   },

--- a/src/styles/v2026.css
+++ b/src/styles/v2026.css
@@ -171,7 +171,11 @@ main { position: relative; z-index: 2; }
 }
 @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
 
-.nav-links { display: flex; gap: 4px; flex-wrap: wrap; }
+/* Nav-logo never wraps */
+.nav-logo { white-space: nowrap; }
+
+/* Nav-links: never wrap — scale instead */
+.nav-links { display: flex; gap: 4px; flex-wrap: nowrap; }
 .nav-links a {
   font-family: var(--font-mono);
   font-size: 13px; letter-spacing: 0.12em; text-transform: uppercase;
@@ -180,6 +184,7 @@ main { position: relative; z-index: 2; }
   border: 1px solid transparent;
   transition: all .18s ease;
   position: relative;
+  white-space: nowrap;
 }
 .nav-links a:hover, .nav-links a.active {
   color: var(--accent-ink);
@@ -201,17 +206,27 @@ main { position: relative; z-index: 2; }
   display: inline-flex; align-items: center; gap: 8px;
   transition: transform .15s ease, background .15s ease;
   border: 2px solid var(--fg);
+  white-space: nowrap;
 }
 .nav-cta:hover { background: var(--accent); border-color: var(--accent); transform: translate(-2px,-2px); box-shadow: 4px 4px 0 var(--accent-ink); }
 
-/* Mid-range: all 6 links + logo + lang-switch + CTA barely fit — compress & drop extras */
-@media (min-width: 861px) and (max-width: 1240px) {
-  .nav-logo { white-space: nowrap; font-size: 11px; gap: 8px; }
-  .nav-links { gap: 2px; flex-wrap: nowrap; }
-  .nav-links a { padding: 7px 9px; font-size: 11px; letter-spacing: 0.07em; }
+/*
+  Responsive nav tiers (desktop only — burger takes over at ≤860px):
+  1400px+  → full desktop: 13px, idx visible, CTA visible
+  1100–1399px → compress: hide idx, smaller padding, no CTA
+   861–1099px → very compact: minimal padding, tiny font, no CTA
+*/
+@media (min-width: 861px) and (max-width: 1399px) {
+  .nav-links a { padding: 8px 10px; font-size: 11px; letter-spacing: 0.07em; }
   .nav-links a .idx { display: none; }
-  .nav-cta { display: none; } /* CTA is in contact section, nav-links link is enough */
-  .nav-inner { gap: 14px; }
+  .nav-links { gap: 2px; }
+  .nav-cta { display: none; }
+  .nav-inner { gap: 12px; }
+}
+@media (min-width: 861px) and (max-width: 1099px) {
+  .nav-links a { padding: 6px 8px; font-size: 10.5px; letter-spacing: 0.05em; }
+  .nav-logo { font-size: 11px; gap: 7px; }
+  .nav-inner { gap: 8px; }
 }
 @media (max-width: 860px) {
   .nav-links { display: none; }

--- a/src/styles/v2026.css
+++ b/src/styles/v2026.css
@@ -204,6 +204,15 @@ main { position: relative; z-index: 2; }
 }
 .nav-cta:hover { background: var(--accent); border-color: var(--accent); transform: translate(-2px,-2px); box-shadow: 4px 4px 0 var(--accent-ink); }
 
+/* Mid-range: all 6 links + logo + lang-switch + CTA barely fit — compress & drop extras */
+@media (min-width: 861px) and (max-width: 1240px) {
+  .nav-logo { white-space: nowrap; font-size: 11px; gap: 8px; }
+  .nav-links { gap: 2px; flex-wrap: nowrap; }
+  .nav-links a { padding: 7px 9px; font-size: 11px; letter-spacing: 0.07em; }
+  .nav-links a .idx { display: none; }
+  .nav-cta { display: none; } /* CTA is in contact section, nav-links link is enough */
+  .nav-inner { gap: 14px; }
+}
 @media (max-width: 860px) {
   .nav-links { display: none; }
 }
@@ -238,9 +247,28 @@ main { position: relative; z-index: 2; }
 }
 .section-title em {
   font-style: normal;
-  color: var(--fg-mute);
-  -webkit-text-stroke: 1px var(--fg-mute);
+  /* Outline state: transparent fill, muted stroke */
   color: transparent;
+  -webkit-text-stroke: 1.5px var(--fg-mute);
+  /* Highlight swipe: accent bg grows left→right */
+  background: linear-gradient(var(--accent), var(--accent)) no-repeat left center;
+  background-size: 0% 88%;
+  padding: 0 6px;
+  margin: 0 -6px;
+  transition:
+    background-size 0.65s cubic-bezier(0.77, 0, 0.18, 1) 0.35s,
+    color 0.01s ease 0.88s,
+    -webkit-text-stroke-color 0.01s ease 0.88s;
+}
+/* When the section-title reveal fires, animate em highlight */
+.section-title.reveal.in em {
+  background-size: 100% 88%;
+  color: var(--accent-ink);
+  -webkit-text-stroke-color: transparent;
+}
+@media (prefers-reduced-motion: reduce) {
+  .section-title em { transition: none; }
+  .section-title.reveal.in em { background-size: 100% 88%; color: var(--accent-ink); }
 }
 
 .section-meta {
@@ -502,8 +530,15 @@ main { position: relative; z-index: 2; }
   background: var(--line);
   border: 1px solid var(--line);
 }
-@media (max-width: 1100px) { .skill-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 640px)  { .skill-grid { grid-template-columns: 1fr; } }
+@media (max-width: 1100px) {
+  .skill-grid { grid-template-columns: repeat(2, 1fr); }
+  /* 3 items in 2-col: 3rd spans full width so it doesn't float alone */
+  .skill-cat:last-child:nth-child(odd) { grid-column: 1 / -1; max-width: 50%; }
+}
+@media (max-width: 640px)  {
+  .skill-grid { grid-template-columns: 1fr; }
+  .skill-cat:last-child:nth-child(odd) { max-width: 100%; }
+}
 
 .skill-cat {
   background: #0e0e0e;


### PR DESCRIPTION
## Changes

- **Nav responsive**: 3-tier system (1400+/1100-1399/861-1099), nowrap globalmente — elimina el doble-row
- **Section title highlight**: `em` con background-size animado al entrar en viewport (efecto subrayado)
- **Back to top**: botón fijo bottom-right, aparece al 50% de scroll
- **Skills grid**: 3er bloque ocupa ancho completo en 2-col (sin huérfano)
- **Social URLs**: LinkedIn locale-aware (es_ES / en_US), GitHub correcto
- **i18n fixes**: CANTABRIAN, CONSULTING, MODE, salto de 3D IMPRESIÓN
- **CSS @layer components**: todo wrapeado correctamente

## Test
- Probar nav en iPad Pro (1024px) y entre 861-1399px
- Verificar efecto de highlight en sección Work/Education/Interests
- Verificar botón go-to-top aparece al mitad de scroll

## Summary by Sourcery

Improve navigation responsiveness, section highlighting, and global UX polish across the site.

New Features:
- Add a fixed back-to-top button that appears after scrolling halfway and smoothly returns the user to the top.
- Animate section title emphasis elements with a viewport-triggered background highlight effect.

Enhancements:
- Adjust desktop navigation to a three-tier responsive layout that prevents wrapping and scales typography and spacing across mid-width breakpoints.
- Ensure nav logo and key nav elements never wrap by enforcing no-wrap behavior on relevant items.
- Refine the skills grid layout so the last item spans full width in two-column mode to avoid a single orphaned card.
- Make LinkedIn social URLs locale-aware via per-locale mappings and correct the GitHub profile URL.