### PR TITLE
fix(a11y): raise text contrast to WCAG AA in both themes

### DIFF
--- a/src/components/Tweaks.astro
+++ b/src/components/Tweaks.astro
@@ -40,13 +40,13 @@
 
   const THEME_DEFAULTS: Record<'dark' | 'light', TweakState> = {
     dark:  { accent: '#C7F23D', grain: 55, density: 1 },
-    light: { accent: '#7a9e17', grain: 18, density: 1 },
+    light: { accent: '#4a6a14', grain: 18, density: 1 },
   };
 
   /* Per-theme swatch palettes */
   const THEME_SWATCHES: Record<'dark' | 'light', string[]> = {
     dark:  ['#C7F23D', '#D4FF3A', '#B8F000', '#FF4500', '#00E5FF', '#FFFFFF'],
-    light: ['#7a9e17', '#5a8a12', '#3d6b0a', '#b35400', '#0066cc', '#8b0000'],
+    light: ['#4a6a14', '#587611', '#3d6b0a', '#b35400', '#0066cc', '#8b0000'],
   };
 
   /* Separate storage keys per theme so they don't bleed into each other */

--- a/src/styles/v2026.css
+++ b/src/styles/v2026.css
@@ -39,7 +39,7 @@
     --line: #2a2a2a;
     --fg: #f4f4ef;
     --fg-dim: #8a8a82;
-    --fg-mute: #4a4a44;
+    --fg-mute: #7c7c74; /* 4.62:1 on --bg (was 2.18:1) */
     --ghost: #2e2e2a;
     --accent: #c7f23d;
     --accent-ink: #0d0d0d;
@@ -98,10 +98,10 @@
       /* Text */
       --fg: #0d0d0d;
       --fg-dim: #5a5a54;
-      --fg-mute: #7a7a72;
+      --fg-mute: #6e6e66; /* 4.67:1 on --bg (was 3.93:1) */
       --ghost: #bdb8a8;
-      /* Accent — dark olive in light mode (brand spec: #7a9e17) */
-      --accent: #7a9e17;
+      /* Accent — dark olive in light mode (brand handoff --mc-accent-dark) */
+      --accent: #4a6a14; /* 5.67:1 as text and as fill (was 2.83:1) */
       --accent-ink: #f5f4ef;
       --grain-opacity: 0.18;
       /* Nav backdrop */
@@ -146,9 +146,9 @@
     --line: #cfcabd;
     --fg: #0d0d0d;
     --fg-dim: #5a5a54;
-    --fg-mute: #7a7a72;
+    --fg-mute: #6e6e66; /* 4.67:1 on --bg (was 3.93:1) */
     --ghost: #bdb8a8;
-    --accent: #7a9e17;
+    --accent: #4a6a14; /* 5.67:1 as text and as fill (was 2.83:1) */
     --accent-ink: #f5f4ef;
     --grain-opacity: 0.18;
     --nav-bg: rgba(245, 244, 239, 0.9);
@@ -183,7 +183,7 @@
     --line: #2a2a2a;
     --fg: #f4f4ef;
     --fg-dim: #8a8a82;
-    --fg-mute: #4a4a44;
+    --fg-mute: #7c7c74; /* 4.62:1 on --bg (was 2.18:1) */
     --ghost: #2e2e2a;
     --accent: #c7f23d;
     --accent-ink: #0d0d0d;


### PR DESCRIPTION
Four text tokens sat below the 4.5:1 minimum for body text. Found while applying the same brand system to another project and measuring the light palette before copying it.

## What changes

| token | theme | before | after | ratio |
|---|---|---|---|---|
| `--fg-mute` | dark | `#4a4a44` | `#7c7c74` | 2.18:1 → **4.62:1** |
| `--fg-mute` | light | `#7a7a72` | `#6e6e66` | 3.93:1 → **4.67:1** |
| `--accent` | light | `#7a9e17` | `#4a6a14` | 2.83:1 → **5.67:1** |

## Why these are real, not pedantry

**`--fg-mute` is not decorative.** It carries hero metadata, work metadata, education dates, quote attribution and interest tags — all at 10–11px. The dark value at 2.18:1 was the worst case in the codebase, and dark is the default theme. (`--ghost` is untouched: that one genuinely is decorative.)

**`--accent` failed in both directions in light mode.** As text on paper it measured 2.83:1, and as a fill with `--accent-ink` on top it also measured 2.83:1 — so lime buttons and lime text were equally hard to read. `#4a6a14` is not an invented value: it is the brand handoff's own `--mc-accent-dark`, documented there as *"Lima oscurecido (contraste sobre paper)"*. It reaches 5.67:1 in both directions.

Dark mode keeps `#C7F23D` untouched at 14.99:1.

## Two things that were easy to miss

The palette is declared **four times** — once per theme under `prefers-color-scheme`, once per theme under the manual `.light` / `.dark` override. Patching only the media queries would have left the theme toggle serving the old values.

`Tweaks.astro` sets `--accent` as an inline style at runtime, which overrides the stylesheet entirely. Its light default had to move too, or the CSS fix would have had no visible effect. Two of its six light swatches also failed (`#7a9e17` 2.83:1, `#5a8a12` 3.75:1) and become `#4a6a14` and `#587611`; the other four light swatches and all six dark swatches already passed.

## Verification

`pnpm build` passes. Values confirmed in the browser from the computed styles on a real page load, in both themes:

- light: `--accent` `#4a6a14` at 5.67:1, `--fg-mute` `#6e6e66` at 4.67:1
- dark: `--accent` `#C7F23D` at 14.99:1, `--fg-mute` `#7c7c74` at 4.62:1, with `--fg-dim` still stronger at 5.59:1 so the hierarchy is preserved

## Worth a look before merging

The light accent is visibly more olive than before — that is the cost of making it legible on paper. If you would rather keep a brighter lime for **fills** while only darkening it for **text**, the alternative is to split the token: keep `#C7F23D` as a non-inverting fill colour with dark ink (14.99:1 in either theme) and use `#4a6a14` only where the accent is text, a border or a link. Happy to redo it that way — say the word.

## Summary by Sourcery

Raise text and accent color contrast to WCAG AA across light and dark themes, including runtime accent defaults and swatches.

Enhancements:
- Increase muted foreground text contrast in both light and dark themes to meet accessibility guidelines.
- Align light theme accent color with brand handoff while achieving sufficient contrast for both text and fill uses.
- Update theme tweak defaults and light accent swatch palette to reflect the new accessible accent colors.